### PR TITLE
Removed --no-suggest

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -99,7 +99,7 @@ runs:
       if: steps.checks1.outputs.uses_composer == 'false'
 
     - name: Install Composer dependencies (with dev)
-      run: composer install --no-progress --no-suggest --prefer-dist --optimize-autoloader
+      run: composer install --no-progress --prefer-dist --optimize-autoloader
       shell: bash
 
     - name: Doing some nessary checks (part II)


### PR DESCRIPTION
This will fix such warning:
```
You are using the deprecated option "--no-suggest". It has no effect and will break in Composer 3.
```
