### PR TITLE
Fixes "Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/"

### DIFF
--- a/bin/app-key.sh
+++ b/bin/app-key.sh
@@ -3,7 +3,7 @@
 CURRENT_APP_KEY="$1"
 
 if [ "$CURRENT_APP_KEY" == "" ]; then
-  echo "::set-output name=app_key::$(php ./bin/console generate:app:key || echo '')"
+  echo "app_key=$(php ./bin/console generate:app:key || echo '')" >> $GITHUB_OUTPUT
 else
-  echo "::set-output name=app_key::$CURRENT_APP_KEY"
+  echo "app_key=$CURRENT_APP_KEY" >> $GITHUB_OUTPUT
 fi;

--- a/bin/uses-composer.sh
+++ b/bin/uses-composer.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 if [ -f "composer.json" ]; then
-  echo "::set-output name=uses_composer::true";
+  echo "uses_composer=true" >> $GITHUB_OUTPUT
 else
-  echo "::set-output name=uses_composer::false";
+  echo "uses_composer=false" >> $GITHUB_OUTPUT
 fi;

--- a/bin/uses-phoenix.sh
+++ b/bin/uses-phoenix.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 if [ -f "./bin/phoenix" ] || [ -f "./bin/phoenix.bat" ]; then
-  echo "::set-output name=uses_phoenix::1";
+  echo "uses_phoenix=1" >> $GITHUB_OUTPUT
 else
-  echo "::set-output name=uses_phoenix::0";
+  echo "uses_phoenix=0" >> $GITHUB_OUTPUT
 fi;


### PR DESCRIPTION
See title